### PR TITLE
Changed Cargo.toml for board-game

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -250,6 +250,8 @@ dependencies = [
 [[package]]
 name = "board-game"
 version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "647fc8459363368aae04df3d21da37094430c57dd993d09be2792133d5365e3e"
 dependencies = [
  "arimaa_engine_step",
  "cast_trait",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,7 +40,6 @@ opt-level = 3
 
 [workspace.dependencies]
 # path dependencies
-board-game = { version = "0.8.0", path = "../../board-game-rs" }
 cuda-nn-eval = { path = "cuda-nn-eval" }
 cuda-sys = { path = "cuda-sys" }
 kz-core = { path = "kz-core" }
@@ -54,6 +53,7 @@ pgn-reader = { path = "pgn-reader" }
 anyhow = "1.0.70"
 async-trait = "0.1.68"
 bindgen = "0.64.0"
+board-game = "0.8.2"
 buffered-reader = "1.1.4"
 bytemuck = "1.13.1"
 byteorder = "1.4.3"


### PR DESCRIPTION
I changed the Cargo.toml for board-game from being a path dependency to being a crates.io dependencies, where the crate is published on [crates.io](https://crates.io/crates/board-game)